### PR TITLE
Fix Russian translation for register_nav

### DIFF
--- a/static/i18n/ru.lua
+++ b/static/i18n/ru.lua
@@ -27,7 +27,7 @@ return {
     package_version = "Версия",
     packages_nav = "Пакеты",
     password = "пароль",
-    register_nav = "Регистрация",
+    register_nav = "Зарегистрироватся",
     upload_button_header = "Выберите пакет для загрузки",
     upload_package = "Загрузить пакет",
     upload_success = "Пакет %s загружен успешно",


### PR DESCRIPTION
It should be the "Register" action, not "Registration" as a concept.