### PR TITLE
Fix verification email template

### DIFF
--- a/controllers/register.lua
+++ b/controllers/register.lua
@@ -30,7 +30,7 @@ return {
       local ver_code = u.email_ver_code
       local alternate_url = string.format("%sverifyemail", self.config.base_url)
       local url = string.format("%s?ver_code=%s&email=%s", alternate_url, ver_code, u.email)
-      local message_body = self.i18n("verify_email_body", {u.name, base_url, url, alternate_url, ver_code})
+      local message_body = self.i18n("verify_email_body", {u.name, self.config.base_url, url, alternate_url, ver_code})
       local message_subject = self.i18n("verify_email_subject", {self.i18n("website_name")})
 
       local mailer, err = mail.new({


### PR DESCRIPTION
Fix the `nil` in:

> Hello Vadi. In order to verify your email address for your account with nil, please visit http://localhost:8080/verifyemail?ver_code=cb9c1a5b-6910-4fb2-b457-a9c72a392d90&email=vperetokin@gmail.com

Tested:

![image](https://user-images.githubusercontent.com/110988/66856291-33c8d780-ef85-11e9-8207-ff901e5cd5d7.png)

