### PR TITLE
Generalise User:verify_password design

### DIFF
--- a/controllers/account.lua
+++ b/controllers/account.lua
@@ -13,14 +13,12 @@ return {
   end),
   POST = capture_errors(function(self)
     validate.assert_valid(self.params, {
-      { "new_password", exists = true, min_length = 8, i18n("missing_new_password") },
+      { "new_password", exists = true, min_length = 8, self.i18n("missing_new_password") },
       { "confirm_new_password", equals = self.params.new_password,
-            i18n("confirmation_password_must_match") },
+            self.i18n("confirmation_password_must_match") },
     })
 
-    self.params.password = self.params.old_password
-    self.params.name = self.session.name
-    assert_error(Users:verify_user(self.params), i18n("old_password_mismatch"))
+    assert_error(Users:verify_user(self.session.name, self.params.old_password), self.i18n("old_password_mismatch"))
     Users:update_password(self.session.name, self.params.new_password)
 
     return self.i18n("password_updated")

--- a/controllers/login.lua
+++ b/controllers/login.lua
@@ -10,7 +10,7 @@ return {
     return { render = "login" }
   end),
   POST = capture_errors(function(self)
-    local user = assert_error(Users:verify_user(self.params))
+    local user = assert_error(Users:verify_user(self.params.name, self.params.password))
     self.session.name = user.name
     self.session.admin = user.admin
     return "Successfully logged in!"

--- a/models/users.lua
+++ b/models/users.lua
@@ -46,15 +46,14 @@ function Users:update_password(username, newpassword)
   user:update({password = hash})
 end
 
-function Users:verify_user(params)
-  local user = self:get_user(params.name)
+function Users:verify_user(name, password)
+  local user = self:get_user(name)
   if not user then
     return false, i18n("err_invalid_user")
   end
-  local pass = user.name .. params.password .. token
-  params.password = nil
+  local pass = user.name .. password .. token
   local verified = bcrypt.verify(pass, user.password)
-  pass = nil
+  pass, password = nil, nil
   if verified then
     return user
   else


### PR DESCRIPTION
Generalise `User:verify_password()` design not to leak `self:params` through, as functions with other signatures need to use it now.

Also fix use of i18n() in `account.lua`.

See https://github.com/Mudlet/mudlet-package-repo/pull/16#discussion_r336326960