### PR TITLE
Suggestion for compatibility: Full url in package

### DIFF
--- a/controllers/uploadpackage.lua
+++ b/controllers/uploadpackage.lua
@@ -107,7 +107,7 @@ return {
 
     -- save the file to disk. function defined above.
     save_file(self)
-    local url = string.format(self.config.base_url .. "data/%s/%s/%s/%s", self.session.name, self.params.name, self.params.version, filename)
+    local url = string.format("%sdata/%s/%s/%s/%s", self.config.base_url, self.session.name, self.params.name, self.params.version, filename)
     local user = Users:get_user(self.session.name)
     local package, err = Packages:create({
       name = self.params.name,

--- a/controllers/uploadpackage.lua
+++ b/controllers/uploadpackage.lua
@@ -107,7 +107,7 @@ return {
 
     -- save the file to disk. function defined above.
     save_file(self)
-    local url = string.format("data/%s/%s/%s/%s", self.session.name, self.params.name, self.params.version, filename)
+    local url = string.format(self.config.base_url .. "data/%s/%s/%s/%s", self.session.name, self.params.name, self.params.version, filename)
     local user = Users:get_user(self.session.name)
     local package, err = Packages:create({
       name = self.params.name,
@@ -120,6 +120,6 @@ return {
       extension = file_extension
     })
     assert_error(package, err)
-    return self.i18n("upload_success", {self.config.base_url .. url})
+    return self.i18n("upload_success", {url})
   end)
 }


### PR DESCRIPTION
The mpkg package manager (client) expects the full download url, otherwise it's not possible to download the package.

I tried to change it client side but it's a bit a mess :wink:

If there is a good reason for not having the full download url serverside I'll try again.
This would just make things a lot easier.