### PR TITLE
Make user registration message more intuitive

### DIFF
--- a/static/i18n/de.lua
+++ b/static/i18n/de.lua
@@ -26,7 +26,7 @@ return {
     email_address = "Emailaddresse",
     email_address_wontshare = "Wir werden deine Emailadresse niemals irgendjemandem mitteilen.",
     administrator = "Administrator",
-    user_created = "Benutzer erstellt",
+    user_created = "Thanks for registering! Please check your email address to verify your account.",
     error_header = "FEHLER",
     navigation_title = "Navigationslinks",
     upload_button_header = "Wähle ein Paket zum hochladen",

--- a/static/i18n/en.lua
+++ b/static/i18n/en.lua
@@ -26,7 +26,7 @@ return {
     email_address = "Email address",
     email_address_wontshare = "We'll never share your email with anyone else.",
     administrator = "administrator",
-    user_created = "User created",
+    user_created = "Thanks for registering! Please check your email address to verify your account.",
     error_header = "ERROR",
     navigation_title = "Navigation links",
     upload_button_header = "Select package to upload",

--- a/static/i18n/ru.lua
+++ b/static/i18n/ru.lua
@@ -32,7 +32,7 @@ return {
     upload_button_header = "Выберите пакет для загрузки",
     upload_package = "Загрузить пакет",
     upload_success = "Пакет %s загружен успешно",
-    user_created = "Пользователь создан",
+    user_created = "Thanks for registering! Please check your email address to verify your account.",
     username = "имя пользователя",
     verification_code = "проверочный код",
     verification_mismatch = "Электронная почта и проверочный код не совпадают, пожалуйста, проверьте их и повторите попытку.",


### PR DESCRIPTION
Right now:

![Selection_624](https://user-images.githubusercontent.com/110988/82204768-c491d800-9905-11ea-9c36-5ebb3828b5d3.png)

Make it say something nicer instead.