### PR TITLE
Remove Luacrypto dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ This server will power the Mudlet package repository and server as a reference i
 It is implemented using lapis, which is a lua web framework that runs inside of OpenResty (https://openresty.org/en/), a custom implementation of NginX. We makes use of the follow luarocks:
 
 * lapis https://github.com/leafo/lapis
-* luacrypto https://github.com/luaforge/luacrypto
 * bcrypt http://github.com/mikejsavage/lua-bcrypt
 * i18n https://github.com/kikito/i18n.lua
 * lua-resty-mail https://github.com/GUI/lua-resty-mail
@@ -17,7 +16,6 @@ The eventual aim is to have it available as a docker container which can read a 
 * Install [OpenResty](https://openresty.org/en/installation.html)
 * Install [Luarocks](https://github.com/luarocks/luarocks/wiki/Download)
 * `luarocks install lapis`
-* `luarocks install luacrypto`
 * `luarocks install bcrypt`
 * `luarocks install i18n`
 * `luarocks install lua-resty-mail`


### PR DESCRIPTION
We don't actually need it anymore, Lapis doesn't require it: https://github.com/leafo/lapis/issues/545#issuecomment-367809330

Closes https://github.com/Mudlet/mudlet-package-repo/issues/30.