### PR TITLE
Fix filename parsing when there's multiple periods

### DIFF
--- a/controllers/changepackage.lua
+++ b/controllers/changepackage.lua
@@ -36,7 +36,7 @@ local function save_file(self)
   if not self.params.file then return end
   -- record our current directory so we can change back to it
   local cwd = lfs.currentdir()
-  local file_extension = self.split_string(self.params.file.filename, "%.")[2]
+  local file_extension = string.match(self.params.file.filename, ".+%.(.+)")
 
   -- start in the data directory
   assert_error(lfs.chdir(self.config.data_dir))
@@ -103,7 +103,7 @@ return {
       local fcontent = self.params.file.content
       local zipheader = "PK"
       local mudlet_xml_header = "<!DOCTYPE MudletPackage>"
-      local file_extension = self.split_string(fname, "%.")[2]
+      local file_extension = string.match(fname, ".+%.(.+)")
       filename = string.format("%s-%s.%s", self.params.name, self.params.version, file_extension)
 
       -- validate file extension

--- a/controllers/uploadpackage.lua
+++ b/controllers/uploadpackage.lua
@@ -35,7 +35,7 @@ end
 local function save_file(self)
   -- record our current directory so we can change back to it
   local cwd = lfs.currentdir()
-  local file_extension = self.split_string(self.params.file.filename, "%.")[2]
+  local file_extension = string.match(self.params.file.filename, ".+%.(.+)")
 
   -- start in the data directory
   assert_error(lfs.chdir(self.config.data_dir))

--- a/controllers/uploadpackage.lua
+++ b/controllers/uploadpackage.lua
@@ -89,7 +89,7 @@ return {
     local fcontent = self.params.file.content
     local zipheader = "PK"
     local mudlet_xml_header = "<!DOCTYPE MudletPackage>"
-    local file_extension = self.split_string(fname, "%.")[2]
+    local file_extension = string.match(fname, ".+%.(.+)")
     local filename = string.format("%s-%s.%s", self.params.name, self.params.version, file_extension)
 
 


### PR DESCRIPTION
A package like `DarkTheme(v.3).mpackage` was failing to upload due to multiple periods in it, this fixes that up.