### PR TITLE
Don't create sha-# builds for Dockerhub

### DIFF
--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -18,7 +18,6 @@ jobs:
         password: ${{ secrets.DOCKERHUB_PASSWORD }}
         repository: mudlet/mudlet-package-repo
         tag_with_ref: true
-        tag_with_sha: true
         add_git_labels: true
 
     - name: Delete old cluster deployment


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Don't create sha-# builds for Dockerhub
#### Motivation for adding to package repo
Used a few too many options, we don't need the `sha-#####` tag to be made all the time:

![image](https://user-images.githubusercontent.com/110988/83337192-9fb04400-a2b9-11ea-98c6-4c4b64bec229.png)

#### Other info (issues closed, discussion etc)
