### PR TITLE
Optimise use of mudlet.png

### DIFF
--- a/views/layout.etlua
+++ b/views/layout.etlua
@@ -14,7 +14,7 @@
   </head>
   <body>
     <header id="header">
-      <img style='height: 100%; width: 10%; object-fit: contain; align=left' src="static/images/mudlet.png">
+      <img style='height: 100%; width: 10%; object-fit: contain; align=left' src="static/images/mudlet_192px.png">
     </header>
     <div id="wrapper">
       <main>


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
We unnecessary load a 100kb Mudlet logo that's too big - we can re-use a smaller one to the same effect.
#### Motivation for adding to package repo
Faster loading.
#### Other info (issues closed, discussion etc)
