### PR TITLE
Docker: permissions, volume mapping and code_cashe

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,6 @@ RUN apk del .build-deps
 # Set the working directory
 WORKDIR /usr/src/app
 
-COPY . .
-
 EXPOSE 8080
 
 CMD lapis migrate $LAPIS_ENVIRONMENT && lapis server $LAPIS_ENVIRONMENT

--- a/README.md
+++ b/README.md
@@ -17,24 +17,36 @@ We do not actually make use of lapis-chan, but it served as an example from whic
 
 By choosing Docker you don't have to worry about installing and configuring the dependencies or PostgreSQL yourself.
 
-
+<details>
+  <summary>Steps for Docker:</summary>
+  
 * Install [Docker](https://docs.docker.com/engine/install/)
 * Install [docker-compose](https://docs.docker.com/compose/install/)
-* Setup a Mailgun account and save the credentials as environment variables, for example:
+* Run `docker-compose build` to build the image.
+* Run `docker-compose up` to run the website.
+* Login with `demo` and `supersecretpassword`.
+
+Code Cache is disbled currently so changes to website are reflected immediately. 
+Docker app folder is mapped to current git location so changes made here are served up immediately in the container.
+
+Server can be run in daemon mode by using `docker-compose up -d` and stopped with `docker-compose down`
+
+To delete all data and restart from scratch, `docker-compose rm` and `docker volume rm mudlet-package-repo_postgres`.
+
+* If you'd like to test sending verification emails, you'll need to configure an SMTP provider (ie [gmail](https://support.google.com/mail/answer/7126229?hl=en) or [mailgun](https://www.mailgun.com/)).
 ```bash
 export SMTP_HOST="smtp.mailgun.org"
 export SMTP_PORT="587"
 export SMTP_USERNAME="postmaster@..."
 export SMTP_PASSWORD="..."
 ```
-* Run `docker-compose build` to build the image.
-* Run `docker-compose up` to run the website.
-
-To refresh the website, rebuild and re-run it again.
-
-To delete all data and restart from scratch, `docker-compose rm` and `docker volume rm mudlet-package-repo_postgres`.
+Submit changes via PR, and happy hacking!
+</details>
 
 ## Via local development
+
+<details>
+  <summary>Steps for local:</summary>
 
 * Install [OpenResty](https://openresty.org/en/installation.html)
 * Install [Luarocks](https://github.com/luarocks/luarocks/wiki/Download)
@@ -57,6 +69,7 @@ Finally, start the server with run `lapis server` and visit http://localhost:808
 The code cache is currently turned off, so refreshing the page will show any changes to the code immediately.
 
 Submit changes via PR, and happy hacking!
+</details>
 
 # Translation
 We are using the i18n module by kikito for internationalization. https://github.com/kikito/i18n.lua

--- a/README.md
+++ b/README.md
@@ -26,10 +26,7 @@ By choosing Docker you don't have to worry about installing and configuring the 
 * Run `docker-compose up` to run the website.
 * Login with `demo` and `supersecretpassword`.
 
-Code Cache is disbled currently so changes to website are reflected immediately. 
-Docker app folder is mapped to current git location so changes made here are served up immediately in the container.
-
-Server can be run in daemon mode by using `docker-compose up -d` and stopped with `docker-compose down`
+Server can be run in daemon mode by using `docker-compose up -d` and stopped with `docker-compose down`. The code cache is disabled, so changes can be reflected immediately by refreshing the page.
 
 To delete all data and restart from scratch, `docker-compose rm` and `docker volume rm mudlet-package-repo_postgres`.
 

--- a/config.lua
+++ b/config.lua
@@ -34,7 +34,7 @@ config({'docker'}, {
   postgres = {
     host = "psql"
   },
-  code_cache = "on",
+  custom_user = "user root root;",
   smtp_host = os.getenv("SMTP_HOST"),
   smtp_port = os.getenv("SMTP_PORT"),
   smtp_username = os.getenv("SMTP_USERNAME"),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,8 @@ services:
       - ./web:/var/www
       - ./data:/var/data
       - ./views:/usr/src/app/views
+      - ./controllers:/usr/src/app/controllers
+      - ./models:/usr/src/app/models
     ports:
       - 8080:8080
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
     volumes:
       - ./web:/var/www
       - ./data:/var/data
+      - ./views:/usr/src/app/views
     ports:
       - 8080:8080
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,11 +31,7 @@ services:
       - SMTP_USERNAME
       - SMTP_PASSWORD
     volumes:
-      - ./web:/var/www
-      - ./data:/var/data
-      - ./views:/usr/src/app/views
-      - ./controllers:/usr/src/app/controllers
-      - ./models:/usr/src/app/models
+      - .:/usr/src/app
     ports:
       - 8080:8080
     restart: unless-stopped


### PR DESCRIPTION
Changed config.lua to disable code caching in docker dev environment, mapped . to /usr/src/app so code is read directly from host git repo folder so rebuilding compose project is now no longer needed to reflect any code changes. Changed the docker custom user to give permissions to data outside of container so can write uploaded files.