### PR TITLE
need to install luarocks inspect

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Submit changes via PR, and happy hacking!
 * `sudo apt install libssl-dev` (on Ubuntu)
 * `luarocks install lapis`
 * `luarocks install bcrypt`
+* `luarocks install inspect`
 * `luarocks install i18n`
 * `luarocks install lua-resty-mail`
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
If I didn't install luarocks inspect and did lapis migrate I got:
``` 
lapis migrate
Error: ./config.lua:2: module 'inspect' not found:No LuaRocks module found for inspect
	no field package.preload['inspect']
	no file '/root/.luarocks/share/lua/5.1/inspect.lua'
	no file '/root/.luarocks/share/lua/5.1/inspect/init.lua'
	no file '/usr/local/share/lua/5.1/inspect.lua'
	no file '/usr/local/share/lua/5.1/inspect/init.lua'
	no file './inspect.lua'
	no file '/usr/local/lib/lua/5.1/inspect.lua'
	no file '/usr/local/lib/lua/5.1/inspect/init.lua'
	no file '/usr/share/lua/5.1/inspect.lua'
	no file '/usr/share/lua/5.1/inspect/init.lua'
	no file '/home/manuel/.luarocks/share/lua/5.1/inspect.lua'
	no file '/home/manuel/.luarocks/share/lua/5.1/inspect/init.lua'
	no file '/root/.luarocks/lib/lua/5.1/inspect.so'
	no file '/usr/local/lib/lua/5.1/inspect.so'
	no file './inspect.so'
	no file '/usr/lib/x86_64-linux-gnu/lua/5.1/inspect.so'
	no file '/usr/lib/lua/5.1/inspect.so'
	no file '/usr/local/lib/lua/5.1/loadall.so'
	no file '/home/manuel/.luarocks/lib/lua/5.1/inspect.so'
 * Run with --trace to see traceback
 * Report issues to https://github.com/leafo/lapis/issues
```

#### Motivation for adding to package repo
it won't work without it.

But another question is. Is it even needed? 
After checking config.lua it doesn't seem to be used by anything.