### PR TITLE
Switch to gh docker registry

### DIFF
--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -16,10 +16,11 @@ jobs:
       uses: docker/setup-buildx-action@v1
       
     - name: Login to DockerHub
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
-        username: ${{ secrets.DOCKERHUB_LOGIN }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build image and push to Dockerhub
       id: docker_build
@@ -27,7 +28,7 @@ jobs:
       with:
         context: .
         push: true
-        tags: mudlet/mudlet-package-repo:development
+        tags: ghcr.io/mudlet/mudlet-package-repo:development
         
     - name: Image digest
       run: echo ${{ steps.docker_build.outputs.digest }}

--- a/kube/package-repo-deployment.yaml
+++ b/kube/package-repo-deployment.yaml
@@ -53,7 +53,7 @@ spec:
               secretKeyRef:
                 name: mailgun-settings
                 key: password
-        image: mudlet/mudlet-package-repo:development
+        image: ghcr.io/mudlet/mudlet-package-repo:development
         imagePullPolicy: "Always"
         name: package-repo
         ports:


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions

This will switch all relevant places to reference the docker file from the GitHub registry instead of dockerhub.

#### Motivation for adding to package repo

Docker Hub requires us to pay money...

#### Other info (issues closed, discussion etc)

See https://blog.alexellis.io/docker-is-deleting-open-source-images/
